### PR TITLE
Pin compiler version to Clang 16 for macOS

### DIFF
--- a/meta.yaml.in
+++ b/meta.yaml.in
@@ -19,7 +19,8 @@ requirements:
     - pkg-config
     - fftw >=3.0
     - qt >=5.15,<6
-    - {{ compiler('cxx') }}
+    - {{ compiler('cxx','16') }}         # [osx]
+    - {{ compiler('cxx') }}              # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - {{ cdt('libx11-devel') }}          # [linux]
     - {{ cdt('libxext-devel') }}         # [linux]


### PR DESCRIPTION
This should get around the compilation errors encountererd with LLVM 17