### PR TITLE
Specify macosx_deployment_target for osx cstdlib

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ else
 cxx_compiler_version:
   - 16        # [osx]
 c_stdlib:
+  - macosx_deployment_target # [osx]
   - sysroot         # [linux]
 c_stdlib_version:   # [linux]
   - 2.17            # [linux]


### PR DESCRIPTION
Fixes compilation error leading conda-build asking for a non-existent `c_osx-64` package.